### PR TITLE
[Junie]: Update Junie CLI Version to 1543.13 in Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Each recipe includes complete workflows, prompts, and configuration examples you
 | Input | Description | Default    |
 |-------|-------------|------------|
 | `prompt` | Custom instructions for Junie. Special values: `code-review` for PR reviews, `fix-ci` for CI failure analysis, `minor-fix` for quick PR adjustments. See [Cookbook](COOKBOOK.md) for examples. | -          |
-| `junie_version` | Junie CLI version to install | `1417.47`         |
+| `junie_version` | Junie CLI version to install | `1543.13`         |
 | `model` | Model to use for the primary agent. Available: `sonnet`, `opus`, `gpt`, `gpt-codex`, `gemini-pro`, `gemini-flash`, `grok` | -          |
 | `junie_work_dir` | Working directory for Junie files | `/tmp/junie-work` |
 | `junie_guidelines_filename` | Filename of the guidelines file (should be in `<project-root>/.junie` dir) | `guidelines.md` |

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
   junie_version:
     description: "Version of Junie to use"
     required: false
-    default: "1417.47"
+    default: "1543.13"
   model:
     description: "Model to use for the primary agent"
     required: false


### PR DESCRIPTION

 ## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**

It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).



### 📊 Junie Summary:
### Summary
- Updated Junie CLI version to `1543.13` in `action.yml` and `README.md`.

### Changes
- **action.yml**: Changed the default value of the `junie_version` input parameter from `1417.47` to `1543.13`.
- **README.md**: Updated the "Junie Configuration" table to reflect the new default version `1543.13` for the `junie_version` parameter.

### Verification
- Verified changes using `grep` to ensure the version string `1543.13` is correctly placed in both files at the expected locations.
