### PR TITLE
[Junie]: Update Junie CLI Version to 1668.43 in Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Each recipe includes complete workflows, prompts, and configuration examples you
 | Input | Description | Default    |
 |-------|-------------|------------|
 | `prompt` | Custom instructions for Junie. Special values: `code-review` for PR reviews, `fix-ci` for CI failure analysis, `minor-fix` for quick PR adjustments. See [Cookbook](COOKBOOK.md) for examples. | -          |
-| `junie_version` | Junie CLI version to install | `1588.21`         |
+| `junie_version` | Junie CLI version to install | `1668.43`         |
 | `model` | Model to use for the primary agent. Available: `sonnet`, `opus`, `gpt`, `gpt-codex`, `gemini-pro`, `gemini-flash`, `grok` | -          |
 | `junie_work_dir` | Working directory for Junie files | `/tmp/junie-work` |
 | `junie_guidelines_filename` | Filename of the guidelines file (should be in `<project-root>/.junie` dir) | `guidelines.md` |

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
   junie_version:
     description: "Version of Junie to use"
     required: false
-    default: "1588.21"
+    default: "1668.43"
   model:
     description: "Model to use for the primary agent"
     required: false


### PR DESCRIPTION

 ## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**

It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).



### 📊 Junie Summary:
### Summary
- Updated Junie CLI version to `1668.43` across the project configuration and documentation.

### Changes
- Modified `action.yml` to update the default value of the `junie_version` input parameter to `1668.43`.
- Modified `README.md` to update the default value of `junie_version` in the configuration table to `1668.43`.

### Verification
- Verified the changes by inspecting the modified files and using `grep` to confirm the version update.
