### PR TITLE
[Junie]: Update Junie CLI Version to 1755.50 in Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Each recipe includes complete workflows, prompts, and configuration examples you
 | Input | Description | Default    |
 |-------|-------------|------------|
 | `prompt` | Custom instructions for Junie. Special values: `code-review` for PR reviews, `fix-ci` for CI failure analysis, `minor-fix` for quick PR adjustments. See [Cookbook](COOKBOOK.md) for examples. | -          |
-| `junie_version` | Junie CLI version to install | `1755.37`         |
+| `junie_version` | Junie CLI version to install | `1755.50`         |
 | `model` | Model to use for the primary agent. Available: `sonnet`, `opus`, `gpt`, `gpt-codex`, `gemini-pro`, `gemini-flash`, `grok` | -          |
 | `junie_work_dir` | Working directory for Junie files | `/tmp/junie-work` |
 | `junie_guidelines_filename` | Filename of the guidelines file (should be in `<project-root>/.junie` dir) | `guidelines.md` |

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
   junie_version:
     description: "Version of Junie to use"
     required: false
-    default: "1755.37"
+    default: "1755.50"
   model:
     description: "Model to use for the primary agent"
     required: false


### PR DESCRIPTION

 ## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**

It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).



### 📊 Junie Summary:
### Summary
- Updated Junie CLI version to `1755.50` in `action.yml` and `README.md`.

### Changes
- Modified `action.yml`: Updated the `default` value of the `junie_version` input parameter from `1755.37` to `1755.50`.
- Modified `README.md`: Updated the default version for `junie_version` in the "Junie Configuration" table from `1755.37` to `1755.50`.

### Verification
- Verified using `grep` that all occurrences of the old version (`1755.37`) were removed and the new version (`1755.50`) is correctly placed in both files.
