### PR TITLE
[Junie]: Update Junie CLI Version to 2206.4 in Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Each recipe includes complete workflows, prompts, and configuration examples you
 | Input | Description | Default    |
 |-------|-------------|------------|
 | `prompt` | Custom instructions for Junie. Special values: `code-review` for PR reviews, `fix-ci` for CI failure analysis, `minor-fix` for quick PR adjustments. See [Cookbook](COOKBOOK.md) for examples. | -          |
-| `junie_version` | Junie CLI version to install | `2144.8`         |
+| `junie_version` | Junie CLI version to install | `2206.4`         |
 | `model` | Model to use for the primary agent. Available: `sonnet`, `opus`, `gpt`, `gpt-codex`, `gemini-pro`, `gemini-flash`, `grok` | -          |
 | `junie_work_dir` | Working directory for Junie files | `/tmp/junie-work` |
 | `junie_guidelines_filename` | Filename of the guidelines file (should be in `<project-root>/.junie` dir) | `guidelines.md` |

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
   junie_version:
     description: "Version of Junie to use"
     required: false
-    default: "2144.8"
+    default: "2206.4"
   code_review_feedback_api_base_url:
     description: >
       junie-cloud BFF base URL for the code-review feedback create-link API.


### PR DESCRIPTION

 ## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**

It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).



### 📊 Junie Summary:
### Summary
- Updated the Junie CLI version to `2206.4` in the GitHub Action configuration and documentation.

### Changes
- Modified `action.yml`: Updated the `default` value of the `junie_version` input parameter from `2144.8` to `2206.4`.
- Modified `README.md`: Updated the "Junie Configuration" table to reflect the new default version `2206.4` for the `junie_version` parameter.

### Verification
- Verified the changes in `action.yml` using `grep` to ensure the `default` value was correctly updated.
- Verified the changes in `README.md` using `grep` to ensure the table row was correctly updated.
