### PR TITLE
Restrict YouTrack "started working" comment to jetbrains-team

### DIFF
--- a/src/github/junie/prepare-junie.ts
+++ b/src/github/junie/prepare-junie.ts
@@ -68,7 +68,8 @@ export async function initializeJunieExecution({
         try {
             console.log('Youtrack Payload: ', JSON.stringify(context.payload, null, 2));
             const client = getYouTrackClient(context.payload.youtrackBaseUrl);
-            const commentId = await client.addComment(context.payload.issueId, INIT_COMMENT_BODY);
+            // Restricted to jetbrains-team only: this is an internal status update, not meant for external reporters
+            const commentId = await client.addComment(context.payload.issueId, INIT_COMMENT_BODY, true);
             if (commentId) {
                 core.setOutput(OUTPUT_VARS.YOUTRACK_INIT_COMMENT_ID, commentId);
             }

--- a/src/github/youtrack/client.ts
+++ b/src/github/youtrack/client.ts
@@ -3,6 +3,12 @@
 /**
  * YouTrack API client wrapper
  */
+
+// Id of the "jetbrains-team" YouTrack group. Hardcoded because the dynamic name->id
+// lookup via /api/groups never resolves this group, regardless of the token's
+// permissions - it is simply never returned by that listing endpoint.
+const JETBRAINS_TEAM_GROUP_ID = "10-3";
+
 class YouTrackClient {
 
     private readonly token: string;
@@ -33,17 +39,25 @@ class YouTrackClient {
      *
      * @param issueId - YouTrack issue ID (e.g., PROJ-123)
      * @param text - Comment text in Markdown
+     * @param restrictToJetBrainsTeam - If true, the comment is only visible to the jetbrains-team group
      * @returns comment ID if successful, null otherwise
      */
-    async addComment(issueId: string, text: string): Promise<string | null> {
+    async addComment(issueId: string, text: string, restrictToJetBrainsTeam = false): Promise<string | null> {
         try {
             console.log(`Adding comment to YouTrack issue ${issueId}`);
 
             const url = `${this.baseUrl}/api/issues/${issueId}/comments?fields=id`;
+            const body: Record<string, unknown> = { text };
+            if (restrictToJetBrainsTeam) {
+                body.visibility = {
+                    '$type': 'LimitedVisibility',
+                    permittedGroups: [{ id: JETBRAINS_TEAM_GROUP_ID }],
+                };
+            }
             const response = await fetch(url, {
                 method: 'POST',
                 headers: this.authHeaders,
-                body: JSON.stringify({ text }),
+                body: JSON.stringify(body),
             });
 
             if (!response.ok) {


### PR DESCRIPTION
### Summary
The automated "Hey, it's Junie by JetBrains! I started working..." comment posted to YouTrack issues was publicly visible to everyone, leaking internal status updates (see [JUNIE-3685](https://youtrack.jetbrains.com/issue/JUNIE-3685#focus=Comments-27-14027286.0-0)). It is now restricted to the `jetbrains-team` group only.

### Changes
- `src/github/youtrack/client.ts`: `YouTrackClient.addComment` now accepts an optional `restrictToJetBrainsTeam` flag. When set, it attaches YouTrack's `LimitedVisibility` payload restricting the comment to the `jetbrains-team` group (`permittedGroups: [{id: "10-3"}]`). The group id is hardcoded because, per the referenced upstream fix in [`junie-agent`](https://github.com/JetBrains/junie-agent/commit/6687cc7743cd8e012a15f50603db75de50f94b1), the dynamic name→id lookup via `/api/groups` never resolves this group and silently falls back to public visibility.
- `src/github/junie/prepare-junie.ts`: the "started working" comment posted for YouTrack-triggered workflows now passes `true` for this flag. The final success/failure feedback comment remains visible to the reporter as before.

### Verification
- `bun run typecheck` passes with no errors.
- Full non-integration unit test suite (`bun test test/*.test.ts`): 251/251 tests pass.
- The live `test/integration/youtrack_integration.test.ts` suite requires real YouTrack/GitHub credentials and was not run locally; it should be validated in CI to confirm the token belongs to `jetbrains-team` so it can still locate the restricted comment.
