### PR TITLE
Add code review comment template and logic for completion

### DIFF
--- a/src/entrypoints/give-feedback.ts
+++ b/src/entrypoints/give-feedback.ts
@@ -1,6 +1,6 @@
 import {postJunieCompletionComment} from "../github/operations/comments/feedback";
 import type {FinishFeedbackData} from "../github/operations/comments/types";
-import {JunieExecutionContext} from "../github/context";
+import {isCodeReviewEvent, JunieExecutionContext} from "../github/context";
 import {ActionType} from "./handle-results";
 import {ENV_VARS, OUTPUT_VARS} from "../constants/environment";
 import {formatJunieSummary} from "./format-summary";
@@ -32,6 +32,7 @@ async function writeFeedbackComment(isJobFailed: boolean, initCommentId?: string
             prLink: process.env[ENV_VARS.PR_LINK],
             workingBranch: process.env[OUTPUT_VARS.WORKING_BRANCH],
             codeReviewFeedbackLink: process.env[OUTPUT_VARS.CODE_REVIEW_FEEDBACK_LINK],
+            isCodeReview: isCodeReviewEvent(data.parsedContext),
         }
     }
 

--- a/src/github/operations/comments/feedback.ts
+++ b/src/github/operations/comments/feedback.ts
@@ -548,7 +548,9 @@ function getSuccessBody(repoFullName: string, successData: SuccessFeedbackData) 
             break;
         case "WRITE_COMMENT":
             console.log('No PR or commit - using Junie result');
-            result = SUCCESS_FEEDBACK_COMMENT_WITH_RESULT(successData.junieTitle || 'Task completed', successData.junieSummary || 'No additional details');
+            result = successData.isCodeReview
+                ? (successData.junieSummary || 'No additional details')
+                : SUCCESS_FEEDBACK_COMMENT_WITH_RESULT(successData.junieTitle || 'Task completed', successData.junieSummary || 'No additional details');
             if (successData.codeReviewFeedbackLink) {
                 result += CODE_REVIEW_FEEDBACK_LINK_SECTION(successData.codeReviewFeedbackLink);
             }

--- a/src/github/operations/comments/types.ts
+++ b/src/github/operations/comments/types.ts
@@ -20,6 +20,7 @@ export interface SuccessFeedbackData {
     workingBranch?: string;
     baseBranch?: string;
     codeReviewFeedbackLink?: string;
+    isCodeReview?: boolean;
 }
 
 export interface FailureFeedbackData {

--- a/test/client/client.ts
+++ b/test/client/client.ts
@@ -201,19 +201,21 @@ export class GitHubClient {
     async waitForJunieComment(issueOrPRNumber: number, message: string): Promise<Comment> {
         console.log(`Waiting for Junie to post comment containing "${message}" in issue #${issueOrPRNumber} in ${this.currentRepo}...`);
         let foundComment: Comment | undefined;
+        const expectedMessage = message.toLowerCase();
         await startPoll(
             `Junie didn't post comment containing "${message}" in issue #${issueOrPRNumber}`,
             {},
             async () => {
                 try {
                     const {data: comments} = await this.getAllIssueOrPRComments(issueOrPRNumber);
-                    const junieComment = comments.find(c => c.body?.includes(message));
+                    const junieComment = comments.find(c => c.body?.toLowerCase().includes(expectedMessage));
 
                     if (junieComment) {
                         foundComment = junieComment;
                         console.log(`Found comment with message: "${message}"`);
                         return true;
                     }
+                    console.log(`Comment containing "${message}" not found in issue #${issueOrPRNumber}. All comments:\n${comments.map(c => `--- comment #${c.id} by ${c.user?.login}:\n${c.body || ''}`).join('\n')}`);
                     return false;
                 } catch (error) {
                     console.log(`Comments not yet available for #${issueOrPRNumber}, waiting...`);

--- a/test/comment-feedback.test.ts
+++ b/test/comment-feedback.test.ts
@@ -477,6 +477,28 @@ describe("Comment Feedback Operations", () => {
       });
     });
 
+    test("should not add success line and title for code review comment", async () => {
+      const data: FinishFeedbackData = {
+        ...baseFinishData,
+        isJobFailed: false,
+        successData: {
+          actionToDo: "WRITE_COMMENT",
+          junieTitle: "Analysis complete",
+          junieSummary: "Here are my findings...",
+          isCodeReview: true,
+          codeReviewFeedbackLink: "https://junie.example.com/code-review-feedback?token=abc",
+        },
+      };
+
+      await postJunieCompletionComment(mockOctokit, data);
+
+      const body = updateCommentSpy.mock.calls[0][0].body as string;
+      expect(body).toContain("Here are my findings...");
+      expect(body).toContain("https://junie.example.com/code-review-feedback?token=abc");
+      expect(body).not.toContain("Junie successfully finished!");
+      expect(body).not.toContain("Analysis complete");
+    });
+
     test("should append EAP feedback link for WRITE_COMMENT when provided", async () => {
       const data: FinishFeedbackData = {
         ...baseFinishData,

--- a/test/integration/pr_code_review.test.ts
+++ b/test/integration/pr_code_review.test.ts
@@ -1,6 +1,8 @@
 import {describe, test, beforeAll, afterAll, expect} from "bun:test";
-import {INIT_COMMENT_BODY, SUCCESS_FEEDBACK_COMMENT} from "../../src/constants/github";
+import {INIT_COMMENT_BODY} from "../../src/constants/github";
 import {testClient} from "../client/client";
+
+const CODE_REVIEW_SUMMARY_SECTION = "Summary of Changes";
 
 describe("Code Review: Built-in", () => {
     let repoName: string;
@@ -81,7 +83,8 @@ describe("Code Review: Built-in", () => {
             );
             const expectedLength = 2;
             const commentTexts = filteredComments.map(c => c.body || '').join('\n---\n');
-            expect(filteredComments.length, `Expected at least ${expectedLength} comments, but got ${filteredComments.length}. All filtered comments:\n${commentTexts}`).toBeGreaterThanOrEqual(expectedLength);await testClient.waitForJunieComment(prNumber, SUCCESS_FEEDBACK_COMMENT);
+            expect(filteredComments.length, `Expected at least ${expectedLength} comments, but got ${filteredComments.length}. All filtered comments:\n${commentTexts}`).toBeGreaterThanOrEqual(expectedLength);
+            await testClient.waitForJunieComment(prNumber, CODE_REVIEW_SUMMARY_SECTION);
             testPassed = true;
         },
         900000
@@ -169,7 +172,7 @@ describe("Code Review: On-Demand via comment", () => {
             const expectedLength = 2;
             const commentTexts = filteredComments.map(c => c.body || '').join('\n---\n');
             expect(filteredComments.length, `Expected at least ${expectedLength} comments, but got ${filteredComments.length}. All filtered comments:\n${commentTexts}`).toBeGreaterThanOrEqual(expectedLength);
-            await testClient.waitForJunieComment(prNumber, SUCCESS_FEEDBACK_COMMENT);
+            await testClient.waitForJunieComment(prNumber, CODE_REVIEW_SUMMARY_SECTION);
             testPassed = true;
         },
         900000


### PR DESCRIPTION
Removed the "Junie successfully finished!" part and the PR title from the code review comment. Kept only the rest, starting from "Summary".