### PR TITLE
[Junie]: Update Junie CLI Version to 2651.6 in Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Each recipe includes complete workflows, prompts, and configuration examples you
 | Input | Description | Default    |
 |-------|-------------|------------|
 | `prompt` | Custom instructions for Junie. Special values: `code-review` for PR reviews, `fix-ci` for CI failure analysis, `minor-fix` for quick PR adjustments. See [Cookbook](COOKBOOK.md) for examples. | -          |
-| `junie_version` | Junie CLI version to install | `2651.4`         |
+| `junie_version` | Junie CLI version to install | `2651.6`         |
 | `model` | Model to use for the primary agent. Available: `sonnet`, `opus`, `gpt`, `gpt-codex`, `gemini-pro`, `gemini-flash`, `grok` | -          |
 | `junie_work_dir` | Working directory for Junie files | `/tmp/junie-work` |
 | `junie_guidelines_filename` | Filename of the guidelines file (should be in `<project-root>/.junie` dir) | `guidelines.md` |

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ inputs:
   junie_version:
     description: "Version of Junie to use"
     required: false
-    default: "2651.4"
+    default: "2651.6"
   code_review_feedback_api_base_url:
     description: >
       junie-cloud BFF base URL for the code-review feedback create-link API.


### PR DESCRIPTION

 ## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**

It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).



### 📊 Junie Summary:
### Summary
- Updated Junie CLI version from `2651.4` to `2651.6` in the project configuration and documentation.

### Changes
- Modified `action.yml`: Updated the `default` value of the `junie_version` input parameter to `2651.6`.
- Modified `README.md`: Updated the default value for the `junie_version` parameter in the "Junie Configuration" input parameters table to `2651.6`.

### Verification
- Verified the changes in both `action.yml` and `README.md` by inspecting the modified files to ensure the version number was updated correctly and formatting remained intact.
