### PR TITLE
Pin transitive GitHub Actions to immutable SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -173,7 +173,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version: 1.3.0
 
@@ -373,7 +373,7 @@ runs:
     - name: Upload Junie artifacts
       if: always() && steps.prepare.outputs.SHOULD_SKIP != 'true'
       continue-on-error: true
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: junie-artifacts
         path: |
@@ -384,7 +384,7 @@ runs:
         if-no-files-found: warn
         include-hidden-files: true
 
-    - uses: EndBug/add-and-commit@v9
+    - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
       name: Commit changes
       id: commit
       if: steps.prepare.outputs.SHOULD_SKIP != 'true' && inputs.silent_mode != 'true' && (steps.junie-run-results.outputs.ACTION_TO_DO == 'COMMIT_CHANGES' || steps.junie-run-results.outputs.ACTION_TO_DO == 'CREATE_PR' || steps.junie-run-results.outputs.ACTION_TO_DO == 'COMMIT_AND_PUSH')


### PR DESCRIPTION
Repositories with immutable-action policies cannot use the composite action because `setup-bun`, `upload-artifact`, and `add-and-commit` are referenced by mutable major-version tags. Pin those three transitive actions to the commits currently resolved by their respective tags while retaining readable version comments.

This keeps the composite action usable in organizations that require every action, including transitive composite steps, to use a full-length commit SHA.