### PR TITLE
[Junie]: Update Junie CLI Version to 3013.4 in Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Each recipe includes complete workflows, prompts, and configuration examples you
 | Input | Description | Default    |
 |-------|-------------|------------|
 | `prompt` | Custom instructions for Junie. Special values: `code-review` for PR reviews, `fix-ci` for CI failure analysis, `minor-fix` for quick PR adjustments. See [Cookbook](COOKBOOK.md) for examples. | -          |
-| `junie_version` | Junie CLI version to install | `3013.3`         |
+| `junie_version` | Junie CLI version to install | `3013.4`         |
 | `model` | Model to use for the primary agent. Available: `sonnet`, `opus`, `gpt`, `gpt-codex`, `gemini-pro`, `gemini-flash`, `grok` | -          |
 | `junie_work_dir` | Working directory for Junie files | `/tmp/junie-work` |
 | `junie_guidelines_filename` | Filename of the guidelines file (should be in `<project-root>/.junie` dir) | `guidelines.md` |

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ inputs:
   junie_version:
     description: "Version of Junie to use"
     required: false
-    default: "3013.3"
+    default: "3013.4"
   code_review_feedback_api_base_url:
     description: >
       junie-cloud BFF base URL for the code-review feedback create-link API.


### PR DESCRIPTION

 ## 📌 Hey! This PR was made for you with Junie, the coding agent by JetBrains **Early Access Preview**

It's still learning, developing, and might make mistakes. Please make sure you review the changes before you accept them.
We'd love your feedback — join our Discord to share bugs, ideas: [here](https://jb.gg/junie/github).



### 📊 Junie Summary:
### Summary
- Updated default Junie CLI version to `3013.4`.

### Changes
- Updated the default value of `junie_version` input parameter to `3013.4` in `action.yml`.
- Updated the default value in the `junie_version` row of the Junie Configuration table in `README.md` to `3013.4`.

### Verification
- Verified changes with `git diff` to confirm accurate replacement of version strings in both files.
